### PR TITLE
fix: changes to unity upload to enable display in slate

### DIFF
--- a/node_common/upload-zip.js
+++ b/node_common/upload-zip.js
@@ -136,7 +136,7 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
 
         data = LibraryManager.createLocalDataIncomplete({
           name: filename,
-          type: mime,
+          type: "application/unity",
         });
 
         const concatStream = concat(_handleZipUpload);

--- a/node_common/upload-zip.js
+++ b/node_common/upload-zip.js
@@ -134,8 +134,11 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
       writableStream.on("file", function (fieldname, stream, filename, encoding, mime) {
         const timeoutId = `${user.username}-${filename}`;
 
+        // NOTE(daniel): Drop the .zip since we are extracting the files
+        const name = filename.split(".zip")[0];
+
         data = LibraryManager.createLocalDataIncomplete({
-          name: filename,
+          name,
           type: "application/unity",
         });
 

--- a/node_common/upload-zip.js
+++ b/node_common/upload-zip.js
@@ -176,7 +176,6 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
                   }
                 )
                 .catch(function (e) {
-                  console.error(e);
                   throw new Error(e.message);
                 });
 


### PR DESCRIPTION
We add a new file type (`application/unity`) for unity games to distinguish it from other files since after extraction and upload, the file does not remain `application/zip`.

This enable us to use `UnityFrame` to display the game in the `SlateMediaObject` in Slate