### PR TITLE
fix: unity loader

### DIFF
--- a/node_common/upload-zip.js
+++ b/node_common/upload-zip.js
@@ -29,6 +29,7 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
   let data = null;
   let dataPath = null;
   let unityGameConfig = null;
+  let unityGameLoader = null;
 
   if (!Strings.isEmpty(originalFileName)) {
     ScriptLogging.log(UPLOAD, `${user.username} is pushing ${originalFileName}`);
@@ -180,10 +181,11 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
                   throw new Error(e.message);
                 });
 
-              // NOTE(daniel): name of unity game config json is dynamic.
-              // Hence, we need to return the name so that we can link to it in the client
+              // NOTE(daniel): detect unity game config file and loader
               if (/build(.*).json/i.test(fileName)) {
                 unityGameConfig = fileName;
+              } else if (/build\/unityloader.js/i.test(fileName)) {
+                unityGameLoader = fileName;
               }
 
               ScriptLogging.message(UPLOADED, `uploaded ${fileName} to root: ${push.root}`);
@@ -261,6 +263,7 @@ export async function formMultipart(req, res, { user, bucketName, originalFileNa
 
     data.size = newUpload.size;
     data.unityGameConfig = unityGameConfig;
+    data.unityGameLoader = unityGameLoader;
 
     console.log("newUpload", newUpload);
 

--- a/pages/upload-zip.js
+++ b/pages/upload-zip.js
@@ -68,7 +68,6 @@ export default async (req, res) => {
   console.log(`[upload] upload for ${user.username} successful`);
 
   const { data, ipfs } = response;
-  console.log("DATAA", data);
 
   const finalData = LibraryManager.updateDataIPFS(data, {
     ipfs,


### PR DESCRIPTION
This PR adds the `json` which contains the unity config game config as `unityGameConfig` and the unity game loader as `unityGameLoader` properties to the `finalData` object which is sent back to the client after the game upload. This ensures that the game is able to load irrespective of the folder structure.