### PR TITLE
multi-download endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@slack/webhook": "^6.0.0",
     "@textile/hub": "^5.2.0",
     "abort-controller": "^3.0.0",
+    "archiver": "^5.2.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "body-parser": "^1.19.0",
     "busboy": "^0.3.1",
@@ -29,10 +30,12 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "ioredis": "^4.23.0",
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.21.16",
     "p-queue": "^6.6.2",
     "pg": "^8.5.1",
+    "request": "^2.88.2",
     "unzipper": "^0.10.11",
     "uuid": "^8.3.2"
   }

--- a/pages/create-zip-token.js
+++ b/pages/create-zip-token.js
@@ -1,0 +1,24 @@
+import { v4 } from "uuid";
+import Redis from "ioredis";
+
+const redisClient = new Redis({
+  port: process.env.REDIS_PORT,
+  host: process.env.REDIS_HOST,
+  password: process.env.REDIS_PASSWORD,
+});
+
+export default async (req, res) => {
+  if (!(req.body?.files && req.body?.files.length > 0)) {
+    return res.status(500).send({ decorator: "SERVER_CREATE_ZIP_TOKEN_INVALID_INPUT" });
+  }
+
+  const token = v4();
+  const files = req.body.files;
+
+  await redisClient.set(token, JSON.stringify(files), "EX", 10 * 60);
+
+  res.status(200).json({
+    decorator: "SERVER_CREATE_ZIP_TOKEN_SUCCESS",
+    data: { token },
+  });
+};

--- a/pages/download-by-token.js
+++ b/pages/download-by-token.js
@@ -1,0 +1,62 @@
+import archiver from "archiver";
+import Request from "request";
+import Redis from "ioredis";
+
+const redisClient = new Redis({
+  port: process.env.REDIS_PORT,
+  host: process.env.REDIS_HOST,
+  password: process.env.REDIS_PASSWORD,
+});
+
+const request = (link) => Request.get(link);
+
+const DOWNLOAD_ERROR_MESSAGE = `
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<script>
+          parent.postMessage('SLATE_DOWNLOAD_ERROR','${process.env.RESOURCE_URI_SLATE}');
+    </script>
+	</head>
+	<body></body>
+</html>`;
+
+export default async (req, res) => {
+  const downloadId = req.query.downloadId;
+  const fileName = req.query.name;
+
+  let files = [];
+  try {
+    files = JSON.parse(await redisClient.get(downloadId));
+    if (!files) throw new Error("invalid files");
+  } catch (e) {
+    console.log(e);
+    return res.status(400).header("Content-Type", "text/html").send(DOWNLOAD_ERROR_MESSAGE);
+  }
+
+  const archive = archiver("zip");
+
+  try {
+    archive.on("warning", function (err) {
+      if (err.code === "ENOENT") {
+        console.log("download warning", err);
+      } else {
+        // throw error
+        throw err;
+      }
+    });
+
+    archive.on("error", function (err) {
+      throw err;
+    });
+
+    res.attachment(fileName);
+    archive.pipe(res);
+    files.forEach((file) => archive.append(request(file.url), { name: file.name }));
+    archive.finalize();
+    redisClient.del(downloadId);
+  } catch (e) {
+    console.log(e);
+    return res.status(500).header("Content-Type", "text/html").send(DOWNLOAD_ERROR_MESSAGE);
+  }
+};

--- a/server.js
+++ b/server.js
@@ -5,14 +5,20 @@ import APIRouteIndex from "~/pages";
 import APIRouteUpload from "~/pages/upload";
 import APIRouteUploadExternal from "~/pages/external-upload";
 import APIRouteUploadZip from "~/pages/upload-zip";
+import APICreateZipToken from "~/pages/create-zip-token";
+import APIDownloadByToken from "~/pages/download-by-token";
 
 import express from "express";
 import cors from "cors";
+import bodyParser from "body-parser";
 
 const server = express();
 const SHOVEL = "SERVER START    ";
 
 server.use(cors());
+
+server.use(bodyParser.json());
+
 server.get("/favicon.ico", (req, res) => res.status(204));
 
 server.get("/", async (req, res) => {
@@ -41,6 +47,18 @@ server.post("/api/deal/:upload", async (req, res) => {
   req.setTimeout(0);
 
   return await APIRouteUpload(req, res, { bucketName: "stage-deal" });
+});
+
+server.post("/api/download/create-zip-token", async (req, res) => {
+  req.setTimeout(0);
+
+  return await APICreateZipToken(req, res);
+});
+
+server.get("/api/download/download-by-token", async (req, res) => {
+  req.setTimeout(0);
+
+  return await APIDownloadByToken(req, res);
 });
 
 const listenServer = server.listen(Environment.PORT, (e) => {


### PR DESCRIPTION
This PR resolved https://github.com/filecoin-project/slate/issues/588

**two new endpoints**
- `/api/download/create-zip-token` will create a token with the metadata about files
- `/api/download/create-zip-token` will use that token to compress and download those files